### PR TITLE
Avoid unnecessary allocations, improve errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ## [0.1.0](https://github.com/nekitdev/expand-tilde/tree/v0.1.0) (2024-10-15)
 
-No significant changes.
+Initial release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expand-tilde"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["nekitdev <nekit@nekit.dev>"]
 edition = "2021"
 description = "Expanding tildes in paths."

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Or by directly specifying it in the configuration like so:
 
 ```toml
 [dependencies]
-expand-tilde = "0.1.0"
+expand-tilde = "0.2.0"
 ```
 
 Alternatively, you can add it directly from the source:

--- a/changelogging.toml
+++ b/changelogging.toml
@@ -1,6 +1,6 @@
 [context]
 name = "expand-tilde"
-version = "0.1.0"
+version = "0.2.0"
 url = "https://github.com/nekitdev/expand-tilde"
 
 [formats]

--- a/changes/2.change.md
+++ b/changes/2.change.md
@@ -1,0 +1,1 @@
+Expansion functions now use `Cow<'_, Path>` to avoid unnecessary allocations.

--- a/changes/2.feature.md
+++ b/changes/2.feature.md
@@ -1,0 +1,1 @@
+Added `home_dir` function which improves diagnostic messages.

--- a/changes/2.internal.md
+++ b/changes/2.internal.md
@@ -1,0 +1,1 @@
+The actual expansion was moved to a separate function, `expand_tilde_path`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,25 +1,48 @@
 //! Expanding tildes in paths.
 //!
+//! If the path starts with the `~` character, it will be expanded to the home directory.
+//!
+//! Any presence of `~` in paths except for the first character will not be expanded.
+//!
+//! The home directory is provided by the [`home_dir`] function.
+//!
 //! # Example
 //!
+//! There are two main ways to expand tildes with this crate;
+//! the first is to use the [`expand_tilde`] function directly:
+//!
 //! ```
-//! use expand_tilde::{ExpandTilde, expand_tilde};
+//! use expand_tilde::expand_tilde;
 //!
 //! let path = "~/.config";
 //!
-//! let direct = expand_tilde(path).unwrap();
+//! let expanded = expand_tilde(path).unwrap();
 //!
-//! let extended = path.expand_tilde().unwrap();
-//!
-//! assert_eq!(direct, extended);
+//! println!("{}", expanded.display());  // something like `/home/nekit/.config`
 //! ```
+//!
+//! And the other way is to use the sealed extension trait:
+//!
+//! ```
+//! use expand_tilde::ExpandTilde;
+//!
+//! let path = "~/.config";
+//!
+//! let expanded = path.expand_tilde().unwrap();
+//!
+//! println!("{}", expanded.display());  // something like `/home/nekit/.config`
+//! ```
+//!
+//! The latter method simply calls the former one under the hood.
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
-use std::path::{Path, PathBuf};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+};
 
-use home::home_dir;
 use miette::Diagnostic;
 use thiserror::Error;
 
@@ -27,9 +50,22 @@ use thiserror::Error;
 ///
 /// The only error that can occur is if the home directory cannot be found.
 #[derive(Debug, Error, Diagnostic)]
-#[error("failed to expand")]
-#[diagnostic(code(expand_tilde), help("make sure the home directory can be found"))]
-pub struct Error;
+pub enum Error {
+    /// The home directory cannot be found.
+    #[error("home directory not found")]
+    #[diagnostic(
+        code(expand_tilde::not_found),
+        help("make sure the home directory exists")
+    )]
+    NotFound,
+    /// The home directory is empty.
+    #[error("home directory is empty")]
+    #[diagnostic(
+        code(expand_tilde::empty),
+        help("make sure the home directory is non-empty")
+    )]
+    Empty,
+}
 
 /// The result type used by this crate.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -37,40 +73,83 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// The `~` literal.
 pub const TILDE: &str = "~";
 
-/// Expands the tilde (`~`) component to the home directory.
+/// Wraps [`home::home_dir`] to improve diagnostics.
 ///
 /// # Errors
 ///
-/// Returns an error if the home directory cannot be found.
-pub fn expand_tilde<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
-    fn expand_tilde_inner(path: &Path) -> Result<PathBuf> {
-        path.strip_prefix(TILDE).map_or_else(
-            |_| Ok(path.to_owned()),
-            |stripped| home_dir().map(|dir| dir.join(stripped)).ok_or(Error),
-        )
-    }
+/// Returns:
+///
+/// - [`Error::NotFound`] if the home directory cannot be found.
+/// - [`Error::Empty`] if the home directory is empty.
+pub fn home_dir() -> Result<PathBuf> {
+    let dir = home::home_dir().ok_or(Error::NotFound)?;
 
-    expand_tilde_inner(path.as_ref())
+    if dir.as_os_str().is_empty() {
+        Err(Error::Empty)
+    } else {
+        Ok(dir)
+    }
+}
+
+/// Expands the tilde (`~`) component to the home directory.
+///
+/// This function is similar to [`expand_tilde_path`], except it is generic over the path type.
+///
+/// # Errors
+///
+/// See [`expand_tilde_path`] for more information.
+pub fn expand_tilde<P: AsRef<Path> + ?Sized>(path: &P) -> Result<Cow<'_, Path>> {
+    expand_tilde_path(path.as_ref())
+}
+
+/// Expands the tilde (`~`) component of the [`Path`] to the home directory.
+///
+/// # Errors
+///
+/// Returns:
+///
+/// - [`Error::NotFound`] if the home directory cannot be found.
+/// - [`Error::Empty`] if the home directory is empty.
+pub fn expand_tilde_path(path: &Path) -> Result<Cow<'_, Path>> {
+    path.strip_prefix(TILDE).map_or_else(
+        |_| Ok(Cow::Borrowed(path)),
+        |stripped| home_dir().map(|dir| Cow::Owned(dir.join(stripped))),
+    )
 }
 
 mod private {
     pub trait Sealed {}
 }
 
-/// Represents paths that can be expanded (sealed extension trait).
+/// Represents values that can be tilde-expanded (sealed extension trait).
 pub trait ExpandTilde: private::Sealed {
     /// Expands the tilde (`~`) component to the home directory.
     ///
     /// # Errors
     ///
-    /// Returns an error if the home directory cannot be found.
-    fn expand_tilde(&self) -> Result<PathBuf>;
+    /// See [`expand_tilde_path`] for more information.
+    fn expand_tilde(&self) -> Result<Cow<'_, Path>>;
 }
 
 impl<P: AsRef<Path>> private::Sealed for P {}
 
 impl<P: AsRef<Path>> ExpandTilde for P {
-    fn expand_tilde(&self) -> Result<PathBuf> {
+    fn expand_tilde(&self) -> Result<Cow<'_, Path>> {
         expand_tilde(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{expand_tilde, ExpandTilde};
+
+    #[test]
+    fn consistent() {
+        let path = "~/.config";
+
+        let expanded = expand_tilde(path).unwrap();
+        let extended = path.expand_tilde().unwrap();
+
+        assert_eq!(expanded, extended);
     }
 }


### PR DESCRIPTION
The `Error` type is now an enum of `NotFound` and `Empty` because we want to handle empty home directories as invalid for expansion.

I also improved the expansion functions so that they do not clone the path in case no expansion occurs.